### PR TITLE
Allow zero arguments for authorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,23 +49,30 @@ For each field you want to authorize via Pundit, add the following code to the f
 
 ```ruby
 field :email do
-  authorize :read_email
+  authorize # will use UserPolicy#email?
   resolve ...
 end
 ```
 
-By default, this will use the Policy for the parent object (the first argument passed to the resolve proc), checking for `:read_email?` for the current user.
+By default, this will use the Policy for the parent object (the first argument passed to the resolve proc), checking for `:email?` for the current user. Sometimes, the field name will differ from the policy method name, in which case you can specify it explicitly:
+
+```ruby
+field :email do
+  authorize :read_email # will use UserPolicy#read_email?
+  resolve ...
+end
+```
 
 Now, in some cases you'll want to use a different policy, or in case of mutations, the passed object might be `nil`:
 
 ```ruby
 field :createUser
-  authorize! :create, User
+  authorize! :create, User # or User.new; will use UserPolicy#create?
   resolve ...
 end
 ```
 
-This will use the `:create?` method of the `UserPolicy`.
+This will use the `:create?` method of the `UserPolicy`. You can also pass in objects instead of a class, if you wish to authorize the user for the specific object.
 
 You might have also noticed the use of `authorize!` instead of `authorize` in this example. The difference between the two is this:
 

--- a/lib/graphql-pundit.rb
+++ b/lib/graphql-pundit.rb
@@ -1,21 +1,24 @@
 # frozen_string_literal: true
+
 require 'graphql-pundit/instrumenter'
 require 'graphql-pundit/version'
 
 require 'graphql'
 
+# Define `authorize` and `authorize!` helpers
 module GraphQL
   def self.assign_authorize(raise_unauthorized)
-    lambda do |defn, query, record = nil|
+    lambda do |defn, query = nil, record = nil|
+      opts = {record: record,
+              query: query || defn.name,
+              raise: raise_unauthorized}
       if query.respond_to?(:call)
-        GraphQL::Define::InstanceDefinable::AssignMetadataKey.new(:authorize).
-          call(defn, proc: query, raise: raise_unauthorized)
-      else
-        GraphQL::Define::InstanceDefinable::AssignMetadataKey.new(:authorize).
-          call(defn, record: record, query: query, raise: raise_unauthorized)
+        opts = {proc: query, raise: raise_unauthorized}
       end
+      Define::InstanceDefinable::AssignMetadataKey.new(:authorize).
+        call(defn, opts)
     end
   end
-  GraphQL::Field.accepts_definitions authorize: assign_authorize(false)
-  GraphQL::Field.accepts_definitions authorize!: assign_authorize(true)
+  Field.accepts_definitions authorize: assign_authorize(false)
+  Field.accepts_definitions authorize!: assign_authorize(true)
 end

--- a/lib/graphql-pundit/instrumenter.rb
+++ b/lib/graphql-pundit/instrumenter.rb
@@ -21,7 +21,11 @@ module GraphQL
             resolve resolve_proc
           end
         else
+          # :nocov:
+          # If no authorization metadata is set, skip and just return the
+          # original field
           field
+          # :nocov:
         end
       end
 

--- a/spec/graphql-pundit/instrumenter_spec.rb
+++ b/spec/graphql-pundit/instrumenter_spec.rb
@@ -17,8 +17,82 @@ class TestPolicy
     @value = value
   end
 
-  def create?
+  def test?
     @value.to_s == 'pass'
+  end
+end
+
+RSpec.shared_examples 'an authorizing field' do |error|
+  context 'Authorized' do
+    subject { pass_test }
+    it 'returns the value' do
+      expect(result).to eq('pass')
+    end
+  end
+
+  context 'Unauthorized' do
+    subject { fail_test }
+    if error
+      it 'raises an execution error' do
+        expect { result }.to raise_error(GraphQL::ExecutionError)
+      end
+    else
+      it 'returns nil' do
+        expect(result).to eq(nil)
+      end
+    end
+  end
+end
+
+RSpec.shared_examples 'field with authorization' do |error|
+  context 'with query' do
+    context 'with name' do
+      let(:field) do
+        GraphQL::Field.define(type: 'String') do
+          name :test
+          if error
+            authorize! :test
+          else
+            authorize :test
+          end
+          resolve ->(obj, _args, _ctx) { obj.to_s }
+        end
+      end
+
+      include_examples 'an authorizing field', error
+    end
+
+    context 'with proc' do
+      let(:field) do
+        GraphQL::Field.define(type: 'String') do
+          name :notTest
+          if error
+            authorize! ->(obj, _args, _ctx) { TestPolicy.new(nil, obj).test? }
+          else
+            authorize ->(obj, _args, _ctx) { TestPolicy.new(nil, obj).test? }
+          end
+          resolve ->(obj, _args, _ctx) { obj.to_s }
+        end
+      end
+
+      include_examples 'an authorizing field', error
+    end
+  end
+
+  context 'without query' do
+    let(:field) do
+      GraphQL::Field.define(type: 'String') do
+        name :test
+        if error
+          authorize!
+        else
+          authorize
+        end
+        resolve ->(obj, _args, _ctx) { obj.to_s }
+      end
+    end
+
+    include_examples 'an authorizing field', error
   end
 end
 
@@ -30,100 +104,10 @@ RSpec.describe GraphQL::Pundit::Instrumenter do
   let(:result) { instrumented_field.resolve(subject, {}, {}) }
 
   context 'authorize' do
-    context 'with symbol' do
-      let(:field) do
-        GraphQL::Field.define(type: 'String') do
-          name 'TestField'
-          authorize :create
-          resolve ->(obj, _args, _ctx) { obj.to_s }
-        end
-      end
+    include_examples 'field with authorization', false
+  end
 
-      context 'Authorized' do
-        subject { pass_test }
-        it 'returns the value' do
-          expect(result).to eq('pass')
-        end
-      end
-
-      context 'Unauthorized' do
-        subject { fail_test }
-        it 'returns nil' do
-          expect(result).to eq(nil)
-        end
-      end
-    end
-
-    context 'authorize!' do
-      let(:field) do
-        GraphQL::Field.define(type: 'String') do
-          name 'TestField'
-          authorize! :create
-          resolve ->(obj, _args, _ctx) { obj.to_s }
-        end
-      end
-
-      context 'Authorized' do
-        subject { pass_test }
-        it 'returns the value' do
-          expect(result).to eq('pass')
-        end
-      end
-
-      context 'Unauthorized' do
-        subject { fail_test }
-        it 'raises an execution error' do
-          expect { result }.to raise_error(GraphQL::ExecutionError)
-        end
-      end
-    end
-
-    context 'with proc' do
-      let(:field) do
-        GraphQL::Field.define(type: 'String') do
-          name 'TestField'
-          authorize ->(obj, _args, _ctx) { TestPolicy.new(nil, obj).create? }
-          resolve ->(obj, _args, _ctx) { obj.to_s }
-        end
-      end
-
-      context 'Authorized' do
-        subject { pass_test }
-        it 'returns the value' do
-          expect(result).to eq('pass')
-        end
-      end
-
-      context 'Unauthorized' do
-        subject { fail_test }
-        it 'returns nil' do
-          expect(result).to eq(nil)
-        end
-      end
-    end
-
-    context 'authorize!' do
-      let(:field) do
-        GraphQL::Field.define(type: 'String') do
-          name 'TestField'
-          authorize! ->(obj, _args, _ctx) { TestPolicy.new(nil, obj).create? }
-          resolve ->(obj, _args, _ctx) { obj.to_s }
-        end
-      end
-
-      context 'Authorized' do
-        subject { pass_test }
-        it 'returns the value' do
-          expect(result).to eq('pass')
-        end
-      end
-
-      context 'Unauthorized' do
-        subject { fail_test }
-        it 'raises an execution error' do
-          expect { result }.to raise_error(GraphQL::ExecutionError)
-        end
-      end
-    end
+  context 'authorize!' do
+    include_examples 'field with authorization', true
   end
 end


### PR DESCRIPTION
Closes #8. ~Hound warnings are addressed in #3.~ It's now based on #3.