### PR TITLE
Allow passing explicit policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,21 @@ Now, in some cases you'll want to use a different policy, or in case of mutation
 
 ```ruby
 field :createUser
-  authorize! :create, User # or User.new; will use UserPolicy#create?
+  authorize! :create, policy: User # or User.new; will use UserPolicy#create?
   resolve ...
 end
 ```
 
-This will use the `:create?` method of the `UserPolicy`. You can also pass in objects instead of a class, if you wish to authorize the user for the specific object.
+This will use the `:create?` method of the `UserPolicy`. You can also pass in objects instead of a class (or symbol), if you wish to authorize the user for the specific object.
+
+If you want to pass a different value to the policy, you can use the keyword argument `record`:
+
+```ruby
+field :createUser
+  authorize! :create, record: User.new # or User.new; will use UserPolicy#create?
+  resolve ...
+end
+```
 
 You might have also noticed the use of `authorize!` instead of `authorize` in this example. The difference between the two is this:
 

--- a/lib/graphql-pundit.rb
+++ b/lib/graphql-pundit.rb
@@ -8,9 +8,10 @@ require 'graphql'
 # Define `authorize` and `authorize!` helpers
 module GraphQL
   def self.assign_authorize(raise_unauthorized)
-    lambda do |defn, query = nil, record = nil|
+    lambda do |defn, query = nil, policy = nil, record = nil|
       opts = {record: record,
               query: query || defn.name,
+              policy: policy,
               raise: raise_unauthorized}
       if query.respond_to?(:call)
         opts = {proc: query, raise: raise_unauthorized}

--- a/lib/graphql-pundit.rb
+++ b/lib/graphql-pundit.rb
@@ -8,7 +8,7 @@ require 'graphql'
 # Define `authorize` and `authorize!` helpers
 module GraphQL
   def self.assign_authorize(raise_unauthorized)
-    lambda do |defn, query = nil, policy = nil, record = nil|
+    lambda do |defn, query = nil, policy: nil, record: nil|
       opts = {record: record,
               query: query || defn.name,
               policy: policy,

--- a/lib/graphql-pundit/instrumenters/authorization.rb
+++ b/lib/graphql-pundit/instrumenters/authorization.rb
@@ -33,8 +33,8 @@ module GraphQL
                          options[:proc].call(obj, args, ctx)
                        else
                          query = options[:query].to_s + '?'
-                         policy = options[:policy] || obj
-                         record = options[:record] || options[:policy] || obj
+                         record = options[:record] || obj
+                         policy = options[:policy] || record
                          policy = ::Pundit::PolicyFinder.new(policy).policy!
                          policy = policy.new(ctx[current_user], record)
                          policy.public_send(query)

--- a/spec/graphql-pundit/instrumenters/authorization_spec.rb
+++ b/spec/graphql-pundit/instrumenters/authorization_spec.rb
@@ -47,25 +47,45 @@ end
 RSpec.shared_examples 'field with authorization' do |error|
   context 'with query' do
     context 'with name' do
-      context 'with record' do
-        let(:field) do
-          subj = subject
-          GraphQL::Field.define(type: 'String') do
-            name :notTest
-            if error
-              authorize! :test, subj
-            else
-              authorize :test, subj
+      context 'with record/policy' do
+        context 'with explicit policy' do
+          let(:field) do
+            subj = subject
+            GraphQL::Field.define(type: 'String') do
+              name :notTest
+              if error
+                authorize! :test, :test, subj.to_s
+              else
+                authorize :test, :test, subj.to_s
+              end
+              resolve ->(obj, _args, _ctx) { obj.to_s }
             end
-            resolve ->(obj, _args, _ctx) { obj.to_s }
           end
-        end
-        let(:result) { instrumented_field.resolve(Test.new('pass'), {}, {}) }
+          let(:result) { instrumented_field.resolve(Test.new('pass'), {}, {}) }
 
-        include_examples 'an authorizing field', error
+          include_examples 'an authorizing field', error
+        end
+
+        context 'with implicit policy' do
+          let(:field) do
+            subj = subject
+            GraphQL::Field.define(type: 'String') do
+              name :notTest
+              if error
+                authorize! :test, subj
+              else
+                authorize :test, subj
+              end
+              resolve ->(obj, _args, _ctx) { obj.to_s }
+            end
+          end
+          let(:result) { instrumented_field.resolve(Test.new('pass'), {}, {}) }
+
+          include_examples 'an authorizing field', error
+        end
       end
 
-      context 'without record' do
+      context 'without record/policy' do
         let(:field) do
           GraphQL::Field.define(type: 'String') do
             name :notTest

--- a/spec/graphql-pundit/instrumenters/authorization_spec.rb
+++ b/spec/graphql-pundit/instrumenters/authorization_spec.rb
@@ -46,46 +46,62 @@ end
 
 RSpec.shared_examples 'field with authorization' do |error|
   context 'with query' do
-    context 'with name' do
-      context 'with record/policy' do
-        context 'with explicit policy' do
-          let(:field) do
-            subj = subject
-            GraphQL::Field.define(type: 'String') do
-              name :notTest
-              if error
-                authorize! :test, :test, subj.to_s
-              else
-                authorize :test, :test, subj.to_s
-              end
-              resolve ->(obj, _args, _ctx) { obj.to_s }
+    context 'with record' do
+      context 'with policy' do
+        let(:field) do
+          subj = subject
+          GraphQL::Field.define(type: 'String') do
+            name :notTest
+            if error
+              authorize! :test, policy: :test, record: subj.to_s
+            else
+              authorize :test, policy: :test, record: subj.to_s
             end
+            resolve ->(obj, _args, _ctx) { obj.to_s }
           end
-          let(:result) { instrumented_field.resolve(Test.new('pass'), {}, {}) }
-
-          include_examples 'an authorizing field', error
         end
+        let(:result) { instrumented_field.resolve(Test.new('pass'), {}, {}) }
 
-        context 'with implicit policy' do
-          let(:field) do
-            subj = subject
-            GraphQL::Field.define(type: 'String') do
-              name :notTest
-              if error
-                authorize! :test, subj
-              else
-                authorize :test, subj
-              end
-              resolve ->(obj, _args, _ctx) { obj.to_s }
-            end
-          end
-          let(:result) { instrumented_field.resolve(Test.new('pass'), {}, {}) }
-
-          include_examples 'an authorizing field', error
-        end
+        include_examples 'an authorizing field', error
       end
 
-      context 'without record/policy' do
+      context 'without policy' do
+        let(:field) do
+          subj = subject
+          GraphQL::Field.define(type: 'String') do
+            name :notTest
+            if error
+              authorize! :test, record: subj
+            else
+              authorize :test, record: subj
+            end
+            resolve ->(obj, _args, _ctx) { obj.to_s }
+          end
+        end
+        let(:result) { instrumented_field.resolve(Test.new('pass'), {}, {}) }
+
+        include_examples 'an authorizing field', error
+      end
+    end
+
+    context 'without record' do
+      context 'with policy' do
+        let(:field) do
+          GraphQL::Field.define(type: 'String') do
+            name :notTest
+            if error
+              authorize! :test, policy: :test
+            else
+              authorize :test, policy: :test
+            end
+            resolve ->(obj, _args, _ctx) { obj.to_s }
+          end
+        end
+
+        include_examples 'an authorizing field', error
+      end
+
+      context 'without policy' do
         let(:field) do
           GraphQL::Field.define(type: 'String') do
             name :notTest
@@ -101,22 +117,22 @@ RSpec.shared_examples 'field with authorization' do |error|
         include_examples 'an authorizing field', error
       end
     end
+  end
 
-    context 'with proc' do
-      let(:field) do
-        GraphQL::Field.define(type: 'String') do
-          name :notTest
-          if error
-            authorize! ->(obj, _args, _ctx) { TestPolicy.new(nil, obj).test? }
-          else
-            authorize ->(obj, _args, _ctx) { TestPolicy.new(nil, obj).test? }
-          end
-          resolve ->(obj, _args, _ctx) { obj.to_s }
+  context 'with proc' do
+    let(:field) do
+      GraphQL::Field.define(type: 'String') do
+        name :notTest
+        if error
+          authorize! ->(obj, _args, _ctx) { TestPolicy.new(nil, obj).test? }
+        else
+          authorize ->(obj, _args, _ctx) { TestPolicy.new(nil, obj).test? }
         end
+        resolve ->(obj, _args, _ctx) { obj.to_s }
       end
-
-      include_examples 'an authorizing field', error
     end
+
+    include_examples 'an authorizing field', error
   end
 
   context 'without query' do


### PR DESCRIPTION
This allows passing of keyword arguments to `authorize`, so a policy and a record can be overridden individually. Note that this is a **breaking change**. Where you previously used

```ruby
authorize :write, Repository
# => RepositoryPolicy.new(current_user, Repository).write?
```

to use `RepositoryPolicy#write?`, you now have to specify it like this:

```ruby
authorize :write, record: Repository
# => RepositoryPolicy.new(current_user, Repository).write?
```

Also possible:

```ruby
authorize :write, policy: Repository # or :repository
# => RepositoryPolicy.new(current_user, parent).write?
```

This would use the parent object in combination with the `RepositoryPolicy`, which was previously impossible (this is the main reason for the change).

You can combine this with `record` like this:

```ruby
authorize :write, policy: :repository, record: RepositoryCompound.new
# => RepositoryPolicy.new(current_user, RepositoryCompound.new).write?
```

to instantiate the `RepositoryPolicy` with `RepositoryCompound.new` and call `write?`, which was also previously impossible.