### PR TITLE
Use RSpec progress bar formatter: Fuubar.

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
---format documentation
 --color
+--format Fuubar
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ notifications:
   email: false
 
 script:
-  - bundle exec rake
+  - bundle exec rspec --format progress

--- a/graphql-pundit.gemspec
+++ b/graphql-pundit.gemspec
@@ -26,11 +26,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'graphql', '>= 1.6.4', '< 1.8.0'
   spec.add_dependency 'pundit', '~> 1.1.0'
 
-  spec.add_development_dependency 'pry', '~> 0.11.0'
   spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'codecov', '~> 0.1.10'
+  spec.add_development_dependency 'fuubar', '~> 2.2.0'
+  spec.add_development_dependency 'pry', '~> 0.11.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
   spec.add_development_dependency 'rubocop', '~> 0.51.0'
   spec.add_development_dependency 'simplecov', '~> 0.15.1'
-  spec.add_development_dependency 'codecov', '~> 0.1.10'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require_relative 'support/simplecov'
 
 require 'bundler/setup'
 require 'graphql-pundit'
+require 'fuubar'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -12,4 +13,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.fuubar_progress_bar_options = {format: '[%B] %c/%C',
+                                        progress_mark: '#',
+                                        remainder_mark: '-'}
 end


### PR DESCRIPTION
This replaces the `progress` formatter (the dots) by the Fuubar formatter (a progress bar) for the development machine. This does not affect Travis.

To see it in action, either check out this branch and run `rspec` or [watch this video of 20 seconds](https://vimeo.com/16845253).