### PR TITLE
Change way of finding policy for scopes

### DIFF
--- a/lib/graphql-pundit/instrumenters/scope.rb
+++ b/lib/graphql-pundit/instrumenters/scope.rb
@@ -43,6 +43,8 @@ module GraphQL
             if !inferred?(scope)
               scope::Scope
             else
+              # Special case for Sequel datasets that do not respond to
+              # ActiveModel's model_name
               infer_from = if root.respond_to?(:model)
                              root.model
                            else

--- a/lib/graphql-pundit/instrumenters/scope.rb
+++ b/lib/graphql-pundit/instrumenters/scope.rb
@@ -19,11 +19,12 @@ module GraphQL
               raise ArgumentError, 'Invalid value passed to `scope`'
             end
 
-            @scope = new_scope(scope)
+            @scope = scope
           end
 
           def call(root, arguments, context)
-            new_scope = scope.call(root, arguments, context)
+            scope_proc = new_scope(scope)
+            new_scope = scope_proc.call(root, arguments, context)
             old_resolver.call(new_scope, arguments, context)
           end
 

--- a/lib/graphql-pundit/version.rb
+++ b/lib/graphql-pundit/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Pundit
-    VERSION = '0.5.0'
+    VERSION = '0.5.1'
   end
 end

--- a/spec/graphql-pundit/instrumenters/scope_spec.rb
+++ b/spec/graphql-pundit/instrumenters/scope_spec.rb
@@ -16,6 +16,12 @@ class ScopeTest
   end
 end
 
+class ScopeTestDataset < ScopeTest
+  def model
+    ScopeTest
+  end
+end
+
 class ScopeTestPolicy
   class Scope
     attr_reader :scope
@@ -55,6 +61,21 @@ RSpec.describe GraphQL::Pundit::Instrumenters::Scope do
 
       it 'filters the list' do
         expect(result).to match_array([1, 2, 3])
+      end
+
+      context 'scope from model' do
+        subject { ScopeTestDataset.new([1, 2, 3, 22, 48]) }
+        let(:field) do
+          GraphQL::Field.define(type: 'String') do
+            name :notTest
+            scope
+            resolve ->(obj, _args, _ctx) { obj.to_a }
+          end
+        end
+
+        it 'filters the list' do
+          expect(result).to match_array([1, 2, 3])
+        end
       end
     end
 
@@ -100,6 +121,22 @@ RSpec.describe GraphQL::Pundit::Instrumenters::Scope do
 
       it 'returns nil' do
         expect(result).to eq(nil)
+      end
+
+      context 'scope from model' do
+        subject { ScopeTestDataset.new([1, 2, 3, 22, 48]) }
+        let(:field) do
+          GraphQL::Field.define(type: 'String') do
+            name :test
+            authorize policy: :scope_test
+            scope
+            resolve ->(obj, _args, _ctx) { obj.to_a }
+          end
+        end
+
+        it 'returns nil' do
+          expect(result).to eq(nil)
+        end
       end
     end
 


### PR DESCRIPTION
Should fix #28. It's not as straight forward as it could be, but unfortunately Pundit only recognizes `model_name`, which is not defined by Sequel.