### PR TITLE
Add alias resolve for resolve_field method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   TargetRubyVersion: 2.5
-  TargetRailsVersion: 5.1
+  # TargetRailsVersion: 5.1
 
   CacheRootDirectory: /tmp
   AllowSymlinksInCacheRootDirectory: true
@@ -24,7 +24,7 @@ AllCops:
     - 'repos/**/*'
     - 'tmp/**/*'
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: false
 
 Layout/DotPosition:
@@ -47,7 +47,7 @@ Metrics/BlockLength:
     - 'db/migrate/*'
     - '*.gemspec'
 
-Metrics/LineLength:
+Layout/LineLength:
   Exclude:
     - 'app/graphql/**/*_enum.rb'
     - 'config/initializers/devise.rb'
@@ -62,7 +62,7 @@ Naming/FileName:
     - lib/ontohub-models.rb
     - spec/lib/git-shell_spec.rb
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Exclude:
     - 'spec/**/*'
 

--- a/graphql-pundit.gemspec
+++ b/graphql-pundit.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'graphql', '>= 1.6.4', '< 1.10.0'
+  spec.add_dependency 'graphql', '>= 1.9.0', '< 1.10.0'
   spec.add_dependency 'pundit', '~> 1.1.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '~> 2.0.2'
   spec.add_development_dependency 'codecov', '~> 0.1.10'
   spec.add_development_dependency 'fuubar', '~> 2.3.0'
   spec.add_development_dependency 'pry', '~> 0.11.0'

--- a/graphql-pundit.gemspec
+++ b/graphql-pundit.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
   spec.add_development_dependency 'rubocop', '~> 0.79.0'
-  spec.add_development_dependency 'simplecov', '~> 0.18.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17.0'
 end

--- a/graphql-pundit.gemspec
+++ b/graphql-pundit.gemspec
@@ -22,18 +22,18 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'graphql', '>= 1.9.0', '< 1.10.0'
-  spec.add_dependency 'pundit', '~> 1.1.0'
+  spec.add_dependency 'graphql', '>= 1.6.4', '< 1.11.0'
+  spec.add_dependency 'pundit', '>= 1.1.0', '< 2.2'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler', '~> 2.1.4'
   spec.add_development_dependency 'codecov', '~> 0.1.10'
-  spec.add_development_dependency 'fuubar', '~> 2.3.0'
-  spec.add_development_dependency 'pry', '~> 0.11.0'
-  spec.add_development_dependency 'pry-byebug', '~> 3.6.0'
+  spec.add_development_dependency 'fuubar', '~> 2.5.0'
+  spec.add_development_dependency 'pry', '~> 0.12.2'
+  spec.add_development_dependency 'pry-byebug', '~> 3.8.0'
   spec.add_development_dependency 'pry-rescue', '~> 1.4.4'
   spec.add_development_dependency 'pry-stack_explorer', '~> 0.4.9.2'
-  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
-  spec.add_development_dependency 'rubocop', '~> 0.57.0'
-  spec.add_development_dependency 'simplecov', '~> 0.16.1'
+  spec.add_development_dependency 'rubocop', '~> 0.79.0'
+  spec.add_development_dependency 'simplecov', '~> 0.18.0'
 end

--- a/graphql-pundit.gemspec
+++ b/graphql-pundit.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'graphql', '>= 1.9.0', '< 1.10.0'
   spec.add_dependency 'pundit', '~> 1.1.0'
 
-  spec.add_development_dependency 'bundler', '~> 2.0.2'
+  spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'codecov', '~> 0.1.10'
   spec.add_development_dependency 'fuubar', '~> 2.3.0'
   spec.add_development_dependency 'pry', '~> 0.11.0'

--- a/lib/graphql-pundit/authorization.rb
+++ b/lib/graphql-pundit/authorization.rb
@@ -48,6 +48,7 @@ module GraphQL
 
       def resolve_helper(obj, args, ctx)
         raise ::Pundit::NotAuthorizedError unless do_authorize(obj, args, ctx)
+
         yield
       rescue ::Pundit::NotAuthorizedError
         raise_graphql_error if @do_raise

--- a/lib/graphql-pundit/authorization.rb
+++ b/lib/graphql-pundit/authorization.rb
@@ -35,7 +35,7 @@ module GraphQL
         @do_raise = true
         authorize(*args, record: record, policy: policy)
       end
-      
+
       def resolve_field(obj, args, ctx)
         resolve_helper(obj, args, ctx) { super(obj, args, ctx) }
       end
@@ -48,6 +48,7 @@ module GraphQL
 
       def resolve_helper(obj, args, ctx)
         raise ::Pundit::NotAuthorizedError unless do_authorize(obj, args, ctx)
+
         yield
       rescue ::Pundit::NotAuthorizedError
         if @do_raise

--- a/lib/graphql-pundit/authorization.rb
+++ b/lib/graphql-pundit/authorization.rb
@@ -38,15 +38,16 @@ module GraphQL
 
       def resolve_field(obj, args, ctx)
         raise ::Pundit::NotAuthorizedError unless do_authorize(obj, args, ctx)
+
         super(obj, args, ctx)
       rescue ::Pundit::NotAuthorizedError
         if @do_raise
           raise GraphQL::ExecutionError, "You're not authorized to do this"
         end
       end
-      
-      alias_method :resolve, :resolve_field
-      
+
+      alias resolve resolve_field
+
       private
 
       def do_authorize(root, arguments, context)

--- a/lib/graphql-pundit/authorization.rb
+++ b/lib/graphql-pundit/authorization.rb
@@ -35,7 +35,7 @@ module GraphQL
         @do_raise = true
         authorize(*args, record: record, policy: policy)
       end
-
+      
       def resolve_field(obj, args, ctx)
         raise ::Pundit::NotAuthorizedError unless do_authorize(obj, args, ctx)
 
@@ -46,8 +46,16 @@ module GraphQL
         end
       end
 
-      alias resolve resolve_field
+      def resolve(obj, args, ctx)
+        raise ::Pundit::NotAuthorizedError unless do_authorize(obj, args, ctx)
 
+        super(obj, args, ctx)
+      rescue ::Pundit::NotAuthorizedError
+        if @do_raise
+          raise GraphQL::ExecutionError, "You're not authorized to do this"
+        end
+      end
+      
       private
 
       def do_authorize(root, arguments, context)

--- a/lib/graphql-pundit/authorization.rb
+++ b/lib/graphql-pundit/authorization.rb
@@ -35,7 +35,7 @@ module GraphQL
         @do_raise = true
         authorize(*args, record: record, policy: policy)
       end
-      
+
       def resolve_field(obj, args, ctx)
         raise ::Pundit::NotAuthorizedError unless do_authorize(obj, args, ctx)
 
@@ -55,7 +55,7 @@ module GraphQL
           raise GraphQL::ExecutionError, "You're not authorized to do this"
         end
       end
-      
+
       private
 
       def do_authorize(root, arguments, context)

--- a/lib/graphql-pundit/authorization.rb
+++ b/lib/graphql-pundit/authorization.rb
@@ -48,12 +48,13 @@ module GraphQL
 
       def resolve_helper(obj, args, ctx)
         raise ::Pundit::NotAuthorizedError unless do_authorize(obj, args, ctx)
-
         yield
       rescue ::Pundit::NotAuthorizedError
-        if @do_raise
-          raise GraphQL::ExecutionError, "You're not authorized to do this"
-        end
+        raise_graphql_error if @do_raise
+      end
+
+      def raise_graphql_error
+        raise GraphQL::ExecutionError, "You're not authorized to do this"
       end
 
       def do_authorize(root, arguments, context)

--- a/lib/graphql-pundit/authorization.rb
+++ b/lib/graphql-pundit/authorization.rb
@@ -35,28 +35,25 @@ module GraphQL
         @do_raise = true
         authorize(*args, record: record, policy: policy)
       end
-
+      
       def resolve_field(obj, args, ctx)
-        raise ::Pundit::NotAuthorizedError unless do_authorize(obj, args, ctx)
-
-        super(obj, args, ctx)
-      rescue ::Pundit::NotAuthorizedError
-        if @do_raise
-          raise GraphQL::ExecutionError, "You're not authorized to do this"
-        end
+        resolve_helper(obj, args, ctx) { super(obj, args, ctx) }
       end
 
       def resolve(obj, args, ctx)
-        raise ::Pundit::NotAuthorizedError unless do_authorize(obj, args, ctx)
+        resolve_helper(obj, args, ctx) { super(obj, args, ctx) }
+      end
 
-        super(obj, args, ctx)
+      private
+
+      def resolve_helper(obj, args, ctx)
+        raise ::Pundit::NotAuthorizedError unless do_authorize(obj, args, ctx)
+        yield
       rescue ::Pundit::NotAuthorizedError
         if @do_raise
           raise GraphQL::ExecutionError, "You're not authorized to do this"
         end
       end
-
-      private
 
       def do_authorize(root, arguments, context)
         return true unless @authorize

--- a/lib/graphql-pundit/authorization.rb
+++ b/lib/graphql-pundit/authorization.rb
@@ -44,7 +44,9 @@ module GraphQL
           raise GraphQL::ExecutionError, "You're not authorized to do this"
         end
       end
-
+      
+      alias_method :resolve, :resolve_field
+      
       private
 
       def do_authorize(root, arguments, context)

--- a/lib/graphql-pundit/common.rb
+++ b/lib/graphql-pundit/common.rb
@@ -8,6 +8,7 @@ module GraphQL
       module ClassMethods
         def current_user(current_user = nil)
           return @current_user unless current_user
+
           @current_user = current_user
         end
       end

--- a/lib/graphql-pundit/field.rb
+++ b/lib/graphql-pundit/field.rb
@@ -5,6 +5,7 @@ require 'graphql-pundit/authorization'
 require 'graphql-pundit/scope'
 
 module GraphQL
+  # Pundit module
   module Pundit
     if defined?(GraphQL::Schema::Field)
       # Field class that contains authorization and scope behavior

--- a/lib/graphql-pundit/instrumenters/authorization.rb
+++ b/lib/graphql-pundit/instrumenters/authorization.rb
@@ -20,6 +20,7 @@ module GraphQL
             unless authorize(root, arguments, context)
               raise ::Pundit::NotAuthorizedError
             end
+
             old_resolver.call(root, arguments, context)
           rescue ::Pundit::NotAuthorizedError
             if options[:raise]
@@ -64,6 +65,7 @@ module GraphQL
 
         def instrument(_type, field)
           return field unless field.metadata[:authorize]
+
           old_resolver = field.resolve_proc
           resolver = AuthorizationResolver.new(current_user,
                                                old_resolver,

--- a/lib/graphql-pundit/instrumenters/scope.rb
+++ b/lib/graphql-pundit/instrumenters/scope.rb
@@ -73,6 +73,7 @@ module GraphQL
           # rubocop:enable Metrics/MethodLength
           scope_metadata = field.metadata[self.class::SCOPE_KEY]
           return field unless scope_metadata
+
           scope = scope_metadata[:proc]
 
           old_resolver = field.resolve_proc

--- a/lib/graphql-pundit/scope.rb
+++ b/lib/graphql-pundit/scope.rb
@@ -37,7 +37,7 @@ module GraphQL
         field_return = super(before_scope_return, args, ctx)
         apply_scope(@after_scope, field_return, args, ctx)
       end
-      
+
       private
 
       def apply_scope(scope, root, arguments, context)

--- a/lib/graphql-pundit/scope.rb
+++ b/lib/graphql-pundit/scope.rb
@@ -32,6 +32,12 @@ module GraphQL
         apply_scope(@after_scope, field_return, args, ctx)
       end
 
+      def resolve(obj, args, ctx)
+        before_scope_return = apply_scope(@before_scope, obj, args, ctx)
+        field_return = super(before_scope_return, args, ctx)
+        apply_scope(@after_scope, field_return, args, ctx)
+      end
+      
       private
 
       def apply_scope(scope, root, arguments, context)

--- a/lib/graphql-pundit/version.rb
+++ b/lib/graphql-pundit/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Pundit
-    VERSION = '0.7.1'
+    VERSION = '0.8.0'
   end
 end

--- a/spec/graphql-pundit/authorization_spec.rb
+++ b/spec/graphql-pundit/authorization_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe GraphQL::Pundit::Authorization do
   let(:record) { nil }
   let(:policy) { nil }
   let(:field_value) { Car.first.name }
-  let(:result) { field.resolve(Car.first, {}, {}) }
+  let(:result) { field.resolve(Car.first, {}, spec_context) }
 
   context 'one-line field definition' do
     let(:field) do
@@ -104,8 +104,7 @@ RSpec.describe GraphQL::Pundit::Authorization do
                 authorize: (do_raise ? nil : query),
                 record: record,
                 policy: policy,
-                null: true).
-        to_graphql
+                null: true)
     end
 
     include_examples 'auth methods'

--- a/spec/graphql-pundit/scope_spec.rb
+++ b/spec/graphql-pundit/scope_spec.rb
@@ -30,7 +30,8 @@ RSpec.shared_examples 'authorizing scopes' do |with_authorization|
   let(:authorize) { true } if with_authorization
 
   context 'before_scope' do
-    let(:resolve) { ->(cars, _, _) { cars.to_a.map(&:name) } }
+    let(:resolve) { :names }
+
     context 'inferred scope' do
       let(:before_scope) { true }
       let(:expected_result) do
@@ -59,7 +60,7 @@ RSpec.shared_examples 'authorizing scopes' do |with_authorization|
   end
 
   context 'after_scope' do
-    let(:resolve) { ->(scope, _, _) { scope.where { |c| c.name.length > 5 } } }
+    let(:resolve) { :longer_then_five }
 
     context 'inferred scope' do
       let(:scope_class) do
@@ -120,7 +121,7 @@ RSpec.describe GraphQL::Pundit::Scope do
   let(:before_scope) { nil }
   let(:after_scope) { nil }
   let(:authorize) { nil }
-  let(:result) { field.resolve(Car, {}, {}) }
+  let(:result) { field.resolve(Car, {}, spec_context) }
   context 'one-line field definition' do
     let(:field) do
       Field.new(name: :name,
@@ -129,8 +130,7 @@ RSpec.describe GraphQL::Pundit::Scope do
                 before_scope: before_scope,
                 after_scope: after_scope,
                 null: true,
-                resolve: resolve).
-        to_graphql
+                resolver_method: resolve)
     end
 
     context 'with failing authorization' do
@@ -147,10 +147,10 @@ RSpec.describe GraphQL::Pundit::Scope do
                         type: [String],
                         authorize: authorize,
                         null: true,
-                        resolve: resolve)
+                        resolver_method: resolve)
       field.before_scope before_scope
       field.after_scope after_scope
-      field.to_graphql
+      field
     end
 
     context 'with failing authorization' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,22 @@ end
 
 Field = GraphQL::Pundit::Field
 
+class BaseObject < GraphQL::Schema::Object
+  field_class GraphQL::Pundit::Field
+end
+
+class Query < BaseObject
+  field :test, Int, null: true
+end
+
+class Schema < GraphQL::Schema
+  query(Query)
+end
+
+def spec_context
+  GraphQL::Query::Context.new(query: Query, schema: Schema, object: {}, values: {})
+end
+
 class CarDataset
   attr_reader :cars
 
@@ -52,6 +68,10 @@ class CarDataset
   def model
     Car
   end
+
+  def names
+    self.to_a.map(&:name)
+  end
 end
 
 class Car
@@ -71,6 +91,14 @@ class Car
 
   def self.first(&block)
     where(&block).first
+  end
+
+  def object
+    self
+  end
+
+  def self.longer_then_five
+    self.where { |c| c.name.length > 5 }
   end
 
   def initialize(name, country)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,10 @@ class Schema < GraphQL::Schema
 end
 
 def spec_context
-  GraphQL::Query::Context.new(query: Query, schema: Schema, object: {}, values: {})
+  GraphQL::Query::Context.new(query: Query,
+                              schema: Schema,
+                              object: {},
+                              values: {})
 end
 
 class CarDataset
@@ -70,7 +73,7 @@ class CarDataset
   end
 
   def names
-    self.to_a.map(&:name)
+    to_a.map(&:name)
   end
 end
 
@@ -98,7 +101,7 @@ class Car
   end
 
   def self.longer_then_five
-    self.where { |c| c.name.length > 5 }
+    where { |c| c.name.length > 5 }
   end
 
   def initialize(name, country)


### PR DESCRIPTION
Compatibility for new `GraphQL::Execution::Interpreter`,  because the interpreter calls a different method:` #resolve(obj, args, ctx)`, instead of `#resolve_field(obj, args, ctx)`.